### PR TITLE
Map actions in AWS to permissions in GCP

### DIFF
--- a/tools/iam-role-mapper-irm/master-sheet/actions_to_permissions.csv
+++ b/tools/iam-role-mapper-irm/master-sheet/actions_to_permissions.csv
@@ -1,0 +1,39 @@
+AWS Actions,GCP Permissions,GCP Role,COMMENTS,
+ec2:RunInstances,compute.instances.create,,,G
+ec2:TerminateInstances,compute.instances.delete,,,G
+ec2:DescribeInstances,compute.instances.list,,,G
+ec2:StartInstances,compute.instances.start,,,G
+ec2:StopInstances,compute.instances.stop,,(SUSPENSION OF AN INSTANCE)Suspending an instance is a feature unique to Google Cloud. Suspending does not deallocate the resources assigned to the Vm and just puts the VM in hold state and incurs no cost during this time frame. ,G
+ec2:RebootInstances,compute.instances.reset,,,G
+ec2:StartInstances,compute.instances.resume,,,G
+ec2:CreateTags,compute.instances.setLabels,,Tags and labels work differently in AWS and GCP. Having some knowledge on them would help in correct usage.,G
+ec2:ModifyInstanceAttribute,compute.instances.setMachineResources,,,G
+ec2:ModifyInstanceAttribute,compute.instances.setMachineType,,,G
+ec2:ModifyInstanceAttribute,compute.instances.setMetadata,,,G
+ec2:ModifyInstanceAttribute,compute.instances.setMinCpuPlatform,,,G
+ec2:ModifyInstanceAttribute,compute.instances.setName,,,G
+ec2:ModifyInstanceAttribute,compute.instances.setScheduling,,,G
+ec2:ModifyInstanceAttribute,compute.instances.setSecurityPolicy,,,G
+iam:LinkRoleToInstanceProfile,compute.instances.setServiceAccount,,,C
+ec2:DetachVolume,compute.instances.detachDisk,,,
+ec2:AttachVolume,compute.instances.attachDisk,,,
+ec2:CreateVolume,compute.disks.create,,,
+ec2:CreateSnapshot,compute.disks.createSnapshot,,,
+ec2:DeleteVolume,compute.disks.delete,,,
+ec2:DescribeVolumes,compute.disks.get,,,
+ec2:DescribeVolumes,compute.disks.list,,,
+ec2:ModifyVolume,compute.disks.resize,,,
+ec2:CreateTags,compute.disks.setLabels,,,
+ec2:ModifyVolume,compute.disks.update,,,
+ec2:AttachVolume,compute.disks.use,,,
+ec2:AllocateAddress,compute.addresses.create,,"The ec2:AllocateAddress action is different from the ec2:CreateAddress action. The ec2:AllocateAddress action only allocates an EIP, but it does not assign it to an EC2 instance. To assign an EIP to an EC2 instance, you must use the ec2:AssociateAddress action.",G
+ec2:ReleaseAddress,compute.addresses.delete,,,
+ec2:DescribeAddresses,compute.addresses.get,,,
+ec2:DescribeAddresses,compute.addresses.list,,,
+ec2:AssociateAddress,compute.addresses.use,,,
+autoscaling:CreateAutoScalingGroup,compute.autoscalers.create,,,
+autoscaling:DeleteAutoScalingGroup,compute.autoscalers.delete,,,
+autoscaling:DescribeAutoScalingGroups,compute.autoscalers.get,,,
+autoscaling:DescribeAutoScalingGroups,compute.autoscalers.list,,,
+autoscaling:UpdateAutoScalingGroup,compute.autoscalers.update,,,
+ec2:ModifyInstanceAttribute,,,,


### PR DESCRIPTION
What has been done in the PR:
- Updated the aws_map variable to have the GCP permissions also
- The aws_map variable is a very complex data structure, and the sample for that has been added as a comment
- Added a new mastersheet as the previous one had a lot of unnecessary and empty lines in the middle

To Do: 
- Shreya has to update the create_pandas_dataframes() as the inputs to that function are no longer available